### PR TITLE
Add dynamic routing examples

### DIFF
--- a/components/layouts/AltLayout.tsx
+++ b/components/layouts/AltLayout.tsx
@@ -1,8 +1,10 @@
-import useSwapi from "../../api/useSwapi"
+import Link from "next/link"
 
 const Layout = ({ children }) => {
   return (
     <>
+      <Link href="/">Home</Link>
+
       <div>
         Alt Layout Nav
       </div>

--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -1,10 +1,13 @@
 import Image from 'next/image';
 import styles from './layout.module.scss';
+import Link from 'next/link';
 
 const Layout = ({ children }) => {
   return (
     <>
       <div className={styles.container}>
+        <Link href="/">Home</Link>
+
         <div>
           Default Layout Navbar
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,6 +25,14 @@ const Home: NextPageWithLayout = () => {
           <li>
             <Link href="/posts/static-generation-post">Static-Generation-Post</Link>
           </li>
+
+          <li>
+            <Link href="/posts/1">PostId: 1 (Post Details Page / Dynamic Route)</Link>
+          </li>
+
+          <li>
+            <Link href="/posts/2">PostId: 2 (Post Details Page / Dynamic Route)</Link>
+          </li>
         </ul>
       
 

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from 'react'
+import type { NextPageWithLayout } from '../_app';
+import AltLayout from '../../components/layouts/AltLayout';
+import { useRouter } from 'next/router';
+
+// Dynamic Routes Example
+const PostDetails: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { id } = router.query
+
+  return <p>Post: {id}</p>
+}
+
+PostDetails.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <AltLayout>
+      {page}
+    </AltLayout>
+  )
+}
+
+export default PostDetails


### PR DESCRIPTION
Why
--
As a dev configuring routes, I should be able to route based on dynamic URL properties (such as ID)

How
--
- Add a single page for PostDetails which requires an ID passed in via URL
- Add Links to PostDetailsPage
- Update Layout and AltLayout navs to include link back to home page