### PR TITLE
Update README and modularize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-This is a starter template for [Learn Next.js](https://nextjs.org/learn).
+# NextJS-101
 
-## Purpose
+A NextJS sample repo with common scenarios built in for quick reference.
 
-When properly implemented, NextJS automatically handles code splitting, dynamic loading, class collisions, routing, and more. This repository demonstrates simple scenarios as intended by NextJS to quick reference.
+## Table of Contents
 
-## Setup
-
-`yarn install`
-
-## Local Development
-
-`yarn run dev`
-`yarn test` to test all files
-`yarn test <path/to/file>` to test specific file
+1. [Purpose](docs/PURPOSE.md)
+1. [Architecture](docs/ARCHITECTURE.md)
+1. [Local Development](docs/LOCAL-DEVELOPMENT.md)
+1. [Source Automation](docs/SOURCE-AUTOMATION.md)
+1. [Build and Deploy](docs/BUILD-AND-DEPLOY.md)

--- a/docs/BUILD-AND-DEPLOY.md
+++ b/docs/BUILD-AND-DEPLOY.md
@@ -1,0 +1,4 @@
+# Build and Deploy
+
+Build configured by NextJS
+Deployment not yet configured

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -1,0 +1,11 @@
+# Local Development
+
+## Setup
+
+`yarn install`
+`yarn run dev`
+
+## Comman
+
+`yarn test` to test all files
+`yarn test <path/to/file>` to test specific file

--- a/docs/PURPOSE.md
+++ b/docs/PURPOSE.md
@@ -1,0 +1,3 @@
+# Purpose
+
+When properly implemented, NextJS automatically handles code splitting, dynamic loading, class collisions, routing, and more. This repository demonstrates simple scenarios as intended by NextJS to quick reference.

--- a/docs/SOURCE-AUTOMATION.md
+++ b/docs/SOURCE-AUTOMATION.md
@@ -1,0 +1,3 @@
+# Source Automation
+
+GitHub Workflow is used to BUILD and TEST code before allowing merger into `main`


### PR DESCRIPTION
Why
--
As a user viewing the ReadMe, I should see meaningful information organized to scale

How
--
- Add a `docs` dir
- Populate docs with quick-win info